### PR TITLE
Ftsensor frame parameter

### DIFF
--- a/include/hybrid_automaton/ForceTorqueSensor.h
+++ b/include/hybrid_automaton/ForceTorqueSensor.h
@@ -58,13 +58,13 @@ namespace ha {
 			return (ForceTorqueSensorPtr(_doClone()));
 		};
 
-        /**
-         * @brief Returns the current force-torque sensor reading as a 6x1 vector.
-         *
-         * Optionally transforms the force into frame _frame_id - PLEASE TEST THIS BEFORE USING!
-         *
-         * x ,y ,z ,rot_x, rot_y, rot_z
-         */
+    /**
+     * @brief Returns the current force-torque sensor reading as a 6x1 vector.
+     *
+     * Optionally transforms the force into frame _frame if parameter is given
+     *
+     * x ,y ,z ,rot_x, rot_y, rot_z
+     */
 		virtual ::Eigen::MatrixXd getCurrentValue() const;
 
 		virtual DescriptionTreeNode::Ptr serialize(const DescriptionTree::ConstPtr& factory) const;
@@ -78,20 +78,20 @@ namespace ha {
 			return sensor;
 		}
 
-		virtual void setFrameId(const std::string& frame_id) {
-			_frame_id = frame_id;
+    virtual void setFrame(const Eigen::MatrixXd& frame) {
+      _frame = frame;
 		}
 
-		virtual std::string getFrameId() const {
-			return _frame_id;
+    virtual ::Eigen::MatrixXd getFrame() const {
+      return _frame;
 		}
 
 	protected:
 
-        /**
-         * @brief Optional frame ID to transform the force into
-         */
-        std::string _frame_id;
+    /**
+     * @brief Optional frame to transform the force into
+     */
+    ::Eigen::MatrixXd _frame;
 
 		// The port of the force-torque sensor to query values from
 		int _port;

--- a/include/hybrid_automaton/ForceTorqueSensor.h
+++ b/include/hybrid_automaton/ForceTorqueSensor.h
@@ -1,28 +1,28 @@
 /*
- * Copyright 2015-2017, Robotics and Biology Lab, TU Berlin
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice, 
- * this list of conditions and the following disclaimer.
- * 
- * 2. Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in the 
- * documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
- * POSSIBILITY OF SUCH DAMAGE.
- */
+* Copyright 2015-2017, Robotics and Biology Lab, TU Berlin
+* 
+* Redistribution and use in source and binary forms, with or without 
+* modification, are permitted provided that the following conditions are met:
+* 
+* 1. Redistributions of source code must retain the above copyright notice, 
+* this list of conditions and the following disclaimer.
+* 
+* 2. Redistributions in binary form must reproduce the above copyright 
+* notice, this list of conditions and the following disclaimer in the 
+* documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+* POSSIBILITY OF SUCH DAMAGE.
+*/
 #ifndef FORCE_TORQUE_SENSOR_H
 #define FORCE_TORQUE_SENSOR_H
 
@@ -37,9 +37,9 @@ namespace ha {
 	typedef boost::shared_ptr<ForceTorqueSensor> ForceTorqueSensorPtr;
 	typedef boost::shared_ptr<const ForceTorqueSensor> ForceTorqueSensorConstPtr;
 
-    /**
-     * @brief An interface to a six-axis force-torque sensor
-     */
+	/**
+	* @brief An interface to a six-axis force-torque sensor
+	*/
 	class ForceTorqueSensor : public Sensor
 	{
 	public:
@@ -58,13 +58,13 @@ namespace ha {
 			return (ForceTorqueSensorPtr(_doClone()));
 		};
 
-    /**
-     * @brief Returns the current force-torque sensor reading as a 6x1 vector.
-     *
-     * Optionally transforms the force into frame _frame if parameter is given
-     *
-     * x ,y ,z ,rot_x, rot_y, rot_z
-     */
+		/**
+		* @brief Returns the current force-torque sensor reading as a 6x1 vector.
+		*
+		* Optionally transforms the force into frame _frame if parameter is given
+		*
+		* x ,y ,z ,rot_x, rot_y, rot_z
+		*/
 		virtual ::Eigen::MatrixXd getCurrentValue() const;
 
 		virtual DescriptionTreeNode::Ptr serialize(const DescriptionTree::ConstPtr& factory) const;
@@ -78,20 +78,35 @@ namespace ha {
 			return sensor;
 		}
 
-    virtual void setFrame(const Eigen::MatrixXd& frame) {
-      _frame = frame;
+
+		virtual void setFrameId(const std::string& frame_id) {
+			_frame_id = frame_id;
 		}
 
-    virtual ::Eigen::MatrixXd getFrame() const {
-      return _frame;
+		virtual std::string getFrameId() const {
+			return _frame_id;
+		}
+
+		virtual void setFrame(const Eigen::MatrixXd& frame) {
+			_frame = frame;
+		}
+
+		virtual ::Eigen::MatrixXd getFrame() const {
+			return _frame;
 		}
 
 	protected:
 
-    /**
-     * @brief Optional frame to transform the force into
-     */
-    ::Eigen::MatrixXd _frame;
+        /**
+         * @brief Optional frame ID to transform the force. Can be either "EE", for force in end-effector frame
+		 * or "world" for force in world coordinate system
+         */
+        std::string _frame_id;
+
+		/**
+		* @brief Optional frame to transform the force into (relative to frame_id)
+		*/
+		::Eigen::MatrixXd _frame;
 
 		// The port of the force-torque sensor to query values from
 		int _port;
@@ -101,7 +116,7 @@ namespace ha {
 			return (new ForceTorqueSensor(*this));
 		}
 
-    ::Eigen::MatrixXd transformWrench(const ::Eigen::MatrixXd& wrench, const ::Eigen::MatrixXd& transform) const;
+		::Eigen::MatrixXd transformWrench(const ::Eigen::MatrixXd& wrench, const ::Eigen::MatrixXd& transform) const;
 	};
 
 }

--- a/include/hybrid_automaton/ForceTorqueSensor.h
+++ b/include/hybrid_automaton/ForceTorqueSensor.h
@@ -101,6 +101,7 @@ namespace ha {
 			return (new ForceTorqueSensor(*this));
 		}
 
+    ::Eigen::MatrixXd transformWrench(const ::Eigen::MatrixXd& wrench, const ::Eigen::MatrixXd& transform) const;
 	};
 
 }

--- a/src/ForceTorqueSensor.cpp
+++ b/src/ForceTorqueSensor.cpp
@@ -110,7 +110,10 @@ namespace ha
 		
 		tree->getAttribute<std::string>("frame_id", _frame_id, "EE");
 		if(_frame_id != "EE" && _frame_id != "world")
-			HA_THROW_ERROR("ForceTorqueSensor.deserialize", "Currently only frame_id EE or world supported. Found "<<_frame_id);
+		{
+			HA_WARN("ForceTorqueSensor.deserialize", "Currently only frame_id EE or world supported. Found "<<_frame_id<<". Will use default value EE!");
+			_frame_id = "EE";
+		}
 
 		_frame.resize(4,4);
 		_frame.setIdentity();

--- a/src/ForceTorqueSensor.cpp
+++ b/src/ForceTorqueSensor.cpp
@@ -49,8 +49,8 @@ namespace ha
 		::Eigen::Vector3d forcePart(wrench(0,0), wrench(1,0),wrench(2,0));
 		::Eigen::Vector3d momentPart(wrench(3,0), wrench(4,0),wrench(5,0));
 
-		forcePart = frameRot*forcePart;
-		momentPart = frameRot*(momentPart - frameTrans.cross(forcePart));
+		forcePart = frameRot.transpose()*forcePart;
+		momentPart = frameRot.transpose()*(momentPart - frameTrans.cross(forcePart));
 
 		Eigen::MatrixXd wrenchOut(6,1);
 		wrenchOut(0) = forcePart(0); wrenchOut(1) = forcePart(1); wrenchOut(2) = forcePart(2);

--- a/src/ForceTorqueSensor.cpp
+++ b/src/ForceTorqueSensor.cpp
@@ -75,6 +75,9 @@ namespace ha
 		//Transform FT wrench to given frame
 		ftOut = transformWrench(ftOut, _frame);
 
+		//if((k++)%2000 == 0)
+		//	HA_INFO("ForceTorqueSensor.getCurrentValue","ftout: "<<ftOut.transpose());
+
 		return ftOut;
 	}
 
@@ -105,10 +108,9 @@ namespace ha
 				<< "invalid - empty or not registered with HybridAutomaton!");
 		}
 		
-		std::string frame_id;
 		tree->getAttribute<std::string>("frame_id", _frame_id, "EE");
-		if(_frame_id != "EE" || "world")
-			HA_THROW_ERROR("ForceTorqueSensor.deserialize", "Currently only frame_id EE or world supported.");
+		if(_frame_id != "EE" && _frame_id != "world")
+			HA_THROW_ERROR("ForceTorqueSensor.deserialize", "Currently only frame_id EE or world supported. Found "<<_frame_id);
 
 		_frame.resize(4,4);
 		_frame.setIdentity();


### PR DESCRIPTION
The FT sensor now can have an optional "frame_id" parameter ( \in {EE, world} ) , which transforms the FT sensor signal (wrench) into the global coordinate system. Another parameter "frame" can be used to perform an additional transformation.

if frame_id and frame are not set, the behavior does not change, so old jump conditions can be used.

This feature will be useful to trigger jump conditions independent of robot configuration, i.e. measure object weight and trigger possible failure.